### PR TITLE
Update project to use Node.js 20.x

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
         workDir: [./front-end]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
         workDir: [./front-end]
         base_href: [vagas-java]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -5,14 +5,14 @@
   "homepage": "https://ionicframework.com/",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
-    "build": "ng build",
-    "test": "ng test",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider ng serve",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider ng build",
+    "test": "NODE_OPTIONS=--openssl-legacy-provider ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
     "ci:clean": "rimraf ./dist",
-    "ci:test": "ng test --watch=false --browsers=ChromeHeadlessCI",
-    "ci:build": "ng build --configuration production"
+    "ci:test": "NODE_OPTIONS=--openssl-legacy-provider ng test --watch=false --browsers=ChromeHeadlessCI",
+    "ci:build": "NODE_OPTIONS=--openssl-legacy-provider ng build --configuration production"
   },
   "private": true,
   "dependencies": {

--- a/front-end/src/index.html
+++ b/front-end/src/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
-  <title>Ionic App</title>
+  <title>SouJava - Vagas Java</title>
 
   <base href="/" />
 


### PR DESCRIPTION
This pull request updates the project to use Node.js 20.x instead of 16.x, and ensures compatibility with the new Node.js version by adding the `--openssl-legacy-provider` flag to all relevant npm scripts. Additionally, it updates the application title in the frontend.

**Node.js version upgrade and compatibility:**
* Updated Node.js version from 16.x to 20.x in GitHub Actions workflows (`.github/workflows/build-test.yml`, `.github/workflows/github-pages.yml`). [[1]](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32L20-R20) [[2]](diffhunk://#diff-983e80aff18936dd64301171c8eec0d019a56ed0e2849985c5ba1c7cb48a8607L24-R24)
* Added `NODE_OPTIONS=--openssl-legacy-provider` to all main npm scripts in `front-end/package.json` to address OpenSSL compatibility issues with Node.js 20.x.

**Frontend improvements:**
* Changed the HTML title in `front-end/src/index.html` from "Ionic App" to "SouJava - Vagas Java".